### PR TITLE
Fixed bad systemd service file when nomad_custom_config is defined

### DIFF
--- a/templates/nomad_systemd.service.j2
+++ b/templates/nomad_systemd.service.j2
@@ -20,6 +20,7 @@ ExecStart={{ nomad_bin_dir }}/nomad agent -{{ nomad_node_role }} \
     -config={{ nomad_config_dir }}/base.hcl \
     -config={{ nomad_config_dir }}/{{ nomad_node_role }}.hcl \
     {% if nomad_config_custom is defined %}-config {{ nomad_config_dir }}/custom.hcl{% endif %}
+
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=on-failure


### PR DESCRIPTION
Without the extra line-break, it joins the lines together, making a mess.
Do you want a new issue?