### PR TITLE
Fix debian init and client only config

### DIFF
--- a/templates/nomad_debian.init.j2
+++ b/templates/nomad_debian.init.j2
@@ -42,13 +42,12 @@ do_start() {
       || return 1
   start-stop-daemon --start --quiet --pidfile "${PIDFILE}" --exec "${DAEMON}" \
       --chuid "${USER}" --background --make-pidfile -- \
-      "${DAEMON_ARGS}" \
+      ${DAEMON_ARGS} \
       || return 2
 
   for i in $(seq 1 30); do
       if ! start-stop-daemon --quiet --stop --test --pidfile "${PIDFILE}" \
               --exec "${DAEMON}" --user "${USER}"; then
-          RETVAL=2
           sleep 1
           continue
       fi
@@ -56,7 +55,7 @@ do_start() {
           return 0
       fi
   done
-  return "${RETVAL}"
+  return 2
 }
 
 do_stop() {

--- a/templates/server.hcl.j2
+++ b/templates/server.hcl.j2
@@ -1,7 +1,9 @@
 server {
     enabled = {{ _nomad_node_server | bool | lower }}
 
-    bootstrap_expect = {{ nomad_servers | count }}
+    {% if _nomad_node_server | bool -%}
+        bootstrap_expect = {{ nomad_servers | count }}
+    {%- endif %}
 
     {% if nomad_retry_join | bool -%}
         retry_join = [


### PR DESCRIPTION
Fixes the debian/ubuntu init script and only sets bootstrap expect for servers.

Other server config is safely ignored if `server{ enabled = false }`, so this is only needed for the bootstrap option.