### PR TITLE
Sane defaults for `bootstrap_expect` when using Consul

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,11 @@ in many Ansible versions, so this feature might not always work.
   assumes consul default ports etc.
 - Default value: **False**
 
+### `nomad_bootstrap_expect`
+
+- Specifies the number of server nodes to wait for before bootstrapping.
+- Default value: `{{ nomad_servers | count or 3 }}}
+
 ### `nomad_vault_address`
 
 - Vault address to use

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,6 +76,7 @@ nomad_reserved:
   ports: "{{ nomad_reserved_ports | default('22', true) }}"
 nomad_options: {}
 nomad_meta: {}
+nomad_bootstrap_expect: "{{ nomad_servers | count or 3 }}"
 
 ### Addresses
 nomad_bind_address: "{{ hostvars[inventory_hostname]['ansible_'+ nomad_iface ]['ipv4']['address'] }}"

--- a/templates/server.hcl.j2
+++ b/templates/server.hcl.j2
@@ -2,7 +2,7 @@ server {
     enabled = {{ _nomad_node_server | bool | lower }}
 
     {% if _nomad_node_server | bool -%}
-        bootstrap_expect = {{ nomad_servers | count }}
+        bootstrap_expect = {{ nomad_bootstrap_expect }}
     {%- endif %}
 
 {% if nomad_use_consul == False %}


### PR DESCRIPTION
Here comes the promised PR for #23. 