### PR TITLE
fix nomad running as a server on ubuntu linux

### DIFF
--- a/templates/nomad_systemd.service.j2
+++ b/templates/nomad_systemd.service.j2
@@ -16,7 +16,11 @@ After=basic.target network.target
 [Service]
 User={{ nomad_user }}
 Group={{ nomad_group }}
-ExecStart={{ nomad_bin_dir }}/nomad agent -config={{ nomad_config_dir }}
+{% if _nomad_node_server | bool -%}
+ExecStart={{ nomad_bin_dir }}/nomad agent -server -config={{ nomad_config_dir }}
+{% else %}
+ExecStart={{ nomad_bin_dir }}/nomad agent  -config={{ nomad_config_dir }}
+{% endif %}
 
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process


### PR DESCRIPTION
On ubuntu linux or a I guess any linux running systemd. It doesn't add the -server so it only starts a client.