### PR TITLE
add nomad_client_iface option

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ The role defines most of its variables in `defaults/main.yml`:
 - Nomad network interface
 - Default value: `{{ ansible_default_ipv4.interface }}`
 
+### `nomad_client_iface`
+
+- Nomad scheduler will choose from the IPs of this interface for allocating tasks
+- Default value: none
+
 ### `nomad_node_name`
 
 - Nomad node name

--- a/README.md
+++ b/README.md
@@ -138,11 +138,6 @@ The role defines most of its variables in `defaults/main.yml`:
 - Nomad network interface
 - Default value: `{{ ansible_default_ipv4.interface }}`
 
-### `nomad_client_iface`
-
-- Nomad scheduler will choose from the IPs of this interface for allocating tasks
-- Default value: none
-
 ### `nomad_node_name`
 
 - Nomad node name
@@ -233,6 +228,11 @@ The role defines most of its variables in `defaults/main.yml`:
 
 - Max kill timeout
 - Default value: **30s**
+
+### `nomad_network_interface`
+
+- Nomad scheduler will choose from the IPs of this interface for allocating tasks
+- Default value: none
 
 ### `nomad_network_speed`
 

--- a/templates/client.hcl.j2
+++ b/templates/client.hcl.j2
@@ -14,8 +14,8 @@ client {
 
     max_kill_timeout = "{{ nomad_max_kill_timeout }}"
 
-    {% if nomad_client_iface is defined -%}
-    network_interface = "{{ nomad_client_iface }}"
+    {% if nomad_network_interface is defined -%}
+    network_interface = "{{ nomad_network_interface }}"
     {% endif -%}
     network_speed = {{ nomad_network_speed }}
     cpu_total_compute = {{ nomad_cpu_total_compute }}

--- a/templates/client.hcl.j2
+++ b/templates/client.hcl.j2
@@ -14,6 +14,9 @@ client {
 
     max_kill_timeout = "{{ nomad_max_kill_timeout }}"
 
+    {% if nomad_client_iface is defined -%}
+    network_interface = "{{ nomad_client_iface }}"
+    {% endif -%}
     network_speed = {{ nomad_network_speed }}
     cpu_total_compute = {{ nomad_cpu_total_compute }}
 


### PR DESCRIPTION
Sets network_interface in client config. That allows to choose interface on which nomad client will allocate tasks