### PR TITLE
Fix client template to correctly include meta data

### DIFF
--- a/templates/client.hcl.j2
+++ b/templates/client.hcl.j2
@@ -34,7 +34,7 @@ client {
 
     {% if nomad_options -%}
     options = {
-    {% for key, value in nomad_options.iteritems() %}
+    {% for key, value in nomad_options.items() %}
     "{{ key }}" = "{{ value }}"
     {% endfor -%}
     }
@@ -42,7 +42,7 @@ client {
 
     {% if nomad_meta -%}
     meta = {
-    {% for key, value in nomad_meta.iteritems() %}
+    {% for key, value in nomad_meta.items() %}
     "{{ key }}" = "{{ value }}"
     {% endfor -%}
     }

--- a/templates/client.hcl.j2
+++ b/templates/client.hcl.j2
@@ -38,7 +38,9 @@ client {
     "{{ key }}" = "{{ value }}"
     {% endfor -%}
     }
+    {% endif %}
 
+    {% if nomad_meta -%}
     meta = {
     {% for key, value in nomad_meta.iteritems() %}
     "{{ key }}" = "{{ value }}"


### PR DESCRIPTION
The metadata config was under the same `if` as the `nomad_options` check. As a result the meta data was not defined if no options where defined.