### PR TITLE
Fix binary file clobbering when installing different architectures at the same time

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -12,6 +12,7 @@
   local_action: stat path="{{ role_path }}/files/nomad_{{ nomad_version }}_SHA256SUMS"
   become: no
   run_once: true
+  tags: installation
   register: nomad_checksum
 
 - name: Get Nomad package checksum file
@@ -24,32 +25,37 @@
 - name: Get Nomad package checksum
   local_action: shell grep "{{ nomad_pkg }}" "{{ role_path }}/files/nomad_{{ nomad_version }}_SHA256SUMS"  | awk '{print $1}'
   become: no
-  run_once: true
   register: nomad_sha256
   tags: installation
 
 - name: Check Nomad package file
   local_action: stat path="{{ role_path }}/files/{{ nomad_pkg }}"
   become: no
-  run_once: true
   register: nomad_package
 
 - name: Download Nomad
   local_action: get_url url="{{ nomad_zip_url }}" dest="{{ role_path }}/files/{{ nomad_pkg }}" checksum="sha256:{{ nomad_sha256.stdout }}" timeout="42"
   become: no
-  run_once: true
   tags: installation
   when: nomad_package.stat.exists == False
 
-- name: Unarchive Nomad
-  local_action: unarchive src="{{ role_path }}/files/{{ nomad_pkg }}" dest="{{ role_path }}/files/" creates="{{ role_path }}/files/nomad"
+- name: Create Temporary Directory for Extraction
+  local_action:
+    module: tempfile
+    state: directory
+    prefix: ansible-nomad.
   become: no
-  run_once: true
+  register: install_temp
+  tags: installation
+
+- name: Unarchive Nomad
+  local_action: unarchive src="{{ role_path }}/files/{{ nomad_pkg }}" dest="{{ install_temp.path }}/" creates="{{ install_temp.path }}/nomad"
+  become: no
   tags: installation
 
 - name: Install Nomad
   copy:
-    src: "{{ role_path }}/files/nomad"
+    src: "{{ install_temp.path }}/nomad"
     dest: "{{ nomad_bin_dir }}"
     owner: "{{ nomad_user }}"
     group: "{{ nomad_group }}"
@@ -57,8 +63,6 @@
   tags: installation
 
 - name: Cleanup
-  local_action: file path="{{ item }}" state="absent"
+  local_action: file path="{{ install_temp.path }}" state="absent"
   become: no
-  with_fileglob: "{{ role_path }}/files/nomad"
-  run_once: true
   tags: installation


### PR DESCRIPTION
I ran into a gotcha where my arm32 and arm64 machines were sometimes getting the wrong binary.

At the expense of some efficiency I've added a fairly simple fix.

- Remove run_once on most of the install steps
- Extract nomad package to a temp folder so that the _nomad_ binary won't conflict with installs for other hosts.
- Cleans Up Folder
- Still does not download nomad package more than once, currently the only cost is extracting the binary each time the play is ran.