### PR TITLE
Updated jinja tests to use ansible 2.5+ syntax

### DIFF
--- a/tasks/asserts.yml
+++ b/tasks/asserts.yml
@@ -9,14 +9,14 @@
 - name: Fail if not a new release of Red Hat / CentOS
   fail:
     msg: "{{ ansible_distribution_version }} is not a supported version of {{ ansible_distribution }} for this role"
-  when: ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_version|version_compare(6, '<')
+  when: ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_version is version_compare(6, '<')
 
 - name: Fail if not a new release of Debian
   fail:
     msg: "{{ ansible_distribution_version }} is not a supported version of {{ ansible_distribution }} for this role"
-  when: ansible_distribution == "Debian" and ansible_distribution_version|version_compare(8.2, '<')
+  when: ansible_distribution == "Debian" and ansible_distribution_version is version_compare(8.2, '<')
 
 - name: Fail if not a new release of Ubuntu
   fail:
     msg: "{{ ansible_distribution_version }} is not a supported version of {{ ansible_distribution }} for this role"
-  when: ansible_distribution == "Ubuntu" and ansible_distribution_version|version_compare(13.04, '<')
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_version is version_compare(13.04, '<')

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -13,7 +13,7 @@
   register: dmsetup_result
   when:
     - ansible_os_family == "Debian"
-    - ansible_distribution_version | version_compare(16.04, '=')
+    - ansible_distribution_version is version_compare(16.04, '=')
     - nomad_docker_dmsetup | bool
 
 - name: Run dmsetup for Ubuntu 16.04


### PR DESCRIPTION
filter syntax deprecated and being removed in ansible 2.9.

https://docs.ansible.com/ansible/2.5/porting_guides/porting_guide_2.5.html#jinja-tests-used-as-filters

-charles.