### PR TITLE
Improve the usage of consul bootstrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,21 @@ in many Ansible versions, so this feature might not always work.
   assumes consul default ports etc.
 - Default value: **False**
 
+### `nomad_consul_address`
+
+- The address of your consul API, use it in combination with nomad_use_consul=True
+- Default value: **localhost:8500**
+
+### `nomad_consul_servers_service_name`
+
+- The name of the consul service for your nomad servers
+- Default value: **nomad-servers**
+
+### `nomad_consul_clients_service_name`
+
+- The name of the consul service for your nomad clients
+- Default value: **nomad-clients**
+
 ### `nomad_bootstrap_expect`
 
 - Specifies the number of server nodes to wait for before bootstrapping.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -91,7 +91,7 @@ nomad_ports:
 ### Servers
 nomad_group_name: "nomad_instances"
 nomad_servers: "\
-  {% if nomad_use_consul==false %}\
+  {% if nomad_use_consul==False %}\
     {% set _nomad_servers = [] %}\
     {% for host in groups[nomad_group_name] %}\
       {% set _nomad_node_role = hostvars[host]['nomad_node_role'] | default('client', true) %}\
@@ -107,6 +107,9 @@ nomad_gather_server_facts: no
 
 ### Consul
 nomad_use_consul: False
+nomad_consul_address: "localhost:8500"
+nomad_consul_servers_service_name: "nomad-servers"
+nomad_consul_clients_service_name: "nomad-clients"
 
 
 ### ACLs

--- a/templates/base.hcl.j2
+++ b/templates/base.hcl.j2
@@ -5,6 +5,7 @@ datacenter = "{{ nomad_datacenter }}"
 enable_debug = {{ nomad_debug | bool | lower }}
 disable_update_check = {{ nomad_disable_update_check | bool | lower }}
 
+
 bind_addr = "{{ nomad_bind_address }}"
 advertise {
     http = "{{ nomad_advertise_address }}"
@@ -16,6 +17,23 @@ ports {
     rpc = {{ nomad_ports['rpc'] }}
     serf = {{ nomad_ports['serf'] }}
 }
+
+{% if nomad_use_consul == True %}
+consul {
+    # The address to the Consul agent.
+    address = "{{ nomad_consul_address }}"
+    # The service name to register the server and client with Consul.
+    server_service_name = "{{ nomad_consul_servers_service_name }}"
+    client_service_name = "{{ nomad_consul_clients_service_name }}"
+
+    # Enables automatically registering the services.
+    auto_advertise = true
+
+    # Enabling the server and client to bootstrap using Consul.
+    server_auto_join = true
+    client_auto_join = true
+}
+{% endif %}
 
 data_dir = "{{ nomad_data_dir }}"
 


### PR DESCRIPTION
Hi, I've been using your nomad & consul roles with ansible, and I though cool to improve a little bit the consul usage of this ansible-nomad role.

- use the consul stanza described here https://www.nomadproject.io/docs/agent/configuration/consul.html
- you can now modify the names of your consul services for the servers
and clients

Not all the variables in the consul Stanza have been mapped, but that's a basis to improve upon.