### PR TITLE
Fix nomad_ports variable references

### DIFF
--- a/templates/base.hcl.j2
+++ b/templates/base.hcl.j2
@@ -8,9 +8,9 @@ disable_update_check = {{ nomad_disable_update_check | bool | lower }}
 
 bind_addr = "{{ nomad_bind_address }}"
 advertise {
-    http = "{{ nomad_advertise_address }}:{{ nomad_ports_http }}"
-    rpc = "{{ nomad_advertise_address }}:{{ nomad_ports_rpc }}"
-    serf = "{{ nomad_advertise_address }}:{{ nomad_ports_serf }}"
+    http = "{{ nomad_advertise_address }}:{{ nomad_ports.http }}"
+    rpc = "{{ nomad_advertise_address }}:{{ nomad_ports.rpc }}"
+    serf = "{{ nomad_advertise_address }}:{{ nomad_ports.serf }}"
 }
 ports {
     http = {{ nomad_ports['http'] }}


### PR DESCRIPTION
The variables `nomad_ports_{http roc serf}` do not have default values assigned to them. When these are not explicitly specified, rendering `template/base.hcl.j2` results in an error. 

This changes those to the ones that do have default values assigned to them.