### PR TITLE
Add check for presence of 'nomad_group_name' group

### DIFF
--- a/tasks/asserts.yml
+++ b/tasks/asserts.yml
@@ -20,3 +20,8 @@
   fail:
     msg: "{{ ansible_distribution_version }} is not a supported version of {{ ansible_distribution }} for this role"
   when: ansible_distribution == "Ubuntu" and ansible_distribution_version is version_compare(13.04, '<')
+
+- name: Check nomad_group_name is included in groups
+  fail:
+    msg: "nomad_group_name must be included in groups."
+  when: nomad_group_name not in groups


### PR DESCRIPTION
Repurposed from the https://github.com/brianshumate/ansible-consul repo. 
The 'Client configuration' task fails without this group present. This will remind people to provide it.