### PR TITLE
Robustify nomad_use_consul check

### DIFF
--- a/templates/base.hcl.j2
+++ b/templates/base.hcl.j2
@@ -18,7 +18,7 @@ ports {
     serf = {{ nomad_ports['serf'] }}
 }
 
-{% if nomad_use_consul == True %}
+{% if nomad_use_consul | bool == True %}
 consul {
     # The address to the Consul agent.
     address = "{{ nomad_consul_address }}"


### PR DESCRIPTION
Using anything other than “True” will result in disabling consul support. 
Casting to a boolean before evaluation enables the use of “true” and “yes” values in the `nomad_use_consul` variable.