### PR TITLE
applying possible fix for sysvinit based system

### DIFF
--- a/templates/nomad_sysvinit.j2
+++ b/templates/nomad_sysvinit.j2
@@ -69,7 +69,7 @@ case "$1" in
         stop
         ;;
     status)
-        "$nomad" info
+        "$nomad" status
         ;;
     restart)
         stop


### PR DESCRIPTION
Hi, here is a possible fix for sysvinit based systems like CentOS/RHEL etc. #48
I've tested this locally using the example provided using `export BOX_NAME=centos/6`.