### PR TITLE
applying additional fixes for enabling sysvinit on centos/rhel

### DIFF
--- a/templates/nomad_sysvinit.j2
+++ b/templates/nomad_sysvinit.j2
@@ -49,7 +49,7 @@ start() {
 
 stop() {
   echo -n "Shutting down nomad: "
-  if ("${nomad}" info 2>/dev/null | grep -q 'server = false' 2>/dev/null) ; then
+  if ("${nomad}" agent-info -address=http://{{ nomad_advertise_address }}:{{ nomad_ports.http }} 2>/dev/null | grep -q 'server = false' 2>/dev/null) ; then
       "$nomad" leave
   fi
 
@@ -69,10 +69,11 @@ case "$1" in
         stop
         ;;
     status)
-        "$nomad" status
+        "$nomad" status -address=http://{{ nomad_advertise_address }}:{{ nomad_ports.http }} 
         ;;
     restart)
         stop
+        sleep 3
         start
         ;;
     reload)


### PR DESCRIPTION
adding `-address` parameter for allowing nomad command to connect to host on bound address other than 127.0.0.1
added delay to restart to allow for process to be finished before trying to start again... might need more error handling depending on how long shut down will take before allowing startup again. For now it is working as expected.
