### PR TITLE
add chroot_env config for exec and java drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,12 @@ The role defines most of its variables in `defaults/main.yml`:
 - Key value dict
 - Default value: **{}**
 
+### `nomad_chroot_env`
+
+- chroot environment definition for the Exec and Java drivers
+- Key value dict
+- Default value: false
+
 ### `nomad_meta`
 
 - Meta data

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -77,6 +77,7 @@ nomad_reserved:
 nomad_options: {}
 nomad_meta: {}
 nomad_bootstrap_expect: "{{ nomad_servers | count or 3 }}"
+nomad_chroot_env: false
 
 ### Addresses
 nomad_bind_address: "{{ hostvars[inventory_hostname]['ansible_'+ nomad_iface ]['ipv4']['address'] }}"

--- a/templates/client.hcl.j2
+++ b/templates/client.hcl.j2
@@ -31,6 +31,10 @@ client {
         disk = {{ nomad_reserved['disk'] }}
     }
 
+    {% if nomad_chroot_env != False -%}
+    chroot_env = {{ nomad_chroot_env | to_nice_json }}
+    {% endif %}
+
     {% if nomad_options -%}
     options = {
     {% for key, value in nomad_options.items() %}


### PR DESCRIPTION
the var nomad_chroot_env holds a list of directories that will
be copied to create a chroot env for the exec or java drivers.
Default value for `nomad_chroot_env` is `False`, making nomad
copy the default set of directories
(https://www.nomadproject.io/docs/configuration/client.html#chroot_env-parameters)