### PR TITLE
feat: production hardening of systemd unit files

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -119,6 +119,21 @@
     mode: 0755
   when: not ansible_service_mgr == "systemd" and ansible_os_family == "Debian"
 
+- name: extract systemd version
+  shell: |
+    set -o pipefail
+    systemctl --version systemd | head -n 1 | cut -d' ' -f2
+  args:
+    executable: /bin/bash
+  changed_when: false
+  check_mode: false
+  register: systemd_version
+  when:
+    - ansible_service_mgr == "systemd"
+    - not ansible_os_family == "FreeBSD"
+    - not ansible_os_family == "Solaris"
+  tags: skip_ansible_lint
+
 - name: systemd script
   template:
     src: nomad_systemd.service.j2

--- a/templates/nomad_systemd.service.j2
+++ b/templates/nomad_systemd.service.j2
@@ -26,6 +26,8 @@ LimitNOFILE=infinity
 LimitNPROC=infinity
 Restart=on-failure
 RestartSec=42s
+StartLimitBurst=3
+StartLimitIntervalSec=10
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/nomad_systemd.service.j2
+++ b/templates/nomad_systemd.service.j2
@@ -22,6 +22,8 @@ ExecStart={{ nomad_bin_dir }}/nomad agent -config={{ nomad_config_dir }}
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 KillSignal=SIGINT
+LimitNOFILE=infinity
+LimitNPROC=infinity
 Restart=on-failure
 RestartSec=42s
 

--- a/templates/nomad_systemd.service.j2
+++ b/templates/nomad_systemd.service.j2
@@ -28,6 +28,9 @@ Restart=on-failure
 RestartSec=42s
 StartLimitBurst=3
 StartLimitIntervalSec=10
+{% if systemd_version.stdout is version('226', '>=') %}
+TasksMax=infinity
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/nomad_systemd.service.j2
+++ b/templates/nomad_systemd.service.j2
@@ -21,6 +21,7 @@ ExecStart={{ nomad_bin_dir }}/nomad agent -config={{ nomad_config_dir }}
 
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
+KillSignal=SIGINT
 Restart=on-failure
 RestartSec=42s
 

--- a/templates/nomad_systemd.service.j2
+++ b/templates/nomad_systemd.service.j2
@@ -10,6 +10,7 @@
 
 [Unit]
 Description=nomad agent
+Documentation=https://nomadproject.io/docs/
 Wants=basic.target
 After=basic.target network.target
 


### PR DESCRIPTION
Hello,

The systemd unit file templated by this role seem unsynchronized from the official recommandations in the documentation https://www.nomadproject.io/guides/install/production/deployment-guide.html#configure-systemd

In this PR I tuned some params about file descriptors and processes limitations that could be problematic for a production cluster.

NB: I know it's possible to override systemd unit file propertries, but having sane default could be great!