### PR TITLE
removed root from group docker

### DIFF
--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -23,6 +23,7 @@
     - dmsetup_result
 
 - name: Add Nomad user to docker group
+  when: "{{ nomad_user }}" != "root"
   user:
     name: "{{ nomad_user }}"
     groups: docker


### PR DESCRIPTION
Don't add root to the "docker" group since it's unnecessary and Proxmox doesn't like root in any other groups.