### PR TITLE
Fix apt package state to present

### DIFF
--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -7,7 +7,7 @@
 - name: Install dmsetup for Ubuntu 16.04
   apt:
     pkg: dmsetup
-    state: installed
+    state: present
     update_cache: true
     cache_valid_time: 600
   register: dmsetup_result


### PR DESCRIPTION
This fixes installation of `dmsetup` package when docker is managed with ansible-nomad role.