### PR TITLE
Added Amazon to list for 'Check distribution compatibility'

### DIFF
--- a/tasks/asserts.yml
+++ b/tasks/asserts.yml
@@ -4,7 +4,7 @@
 - name: Check distribution compatibility
   fail:
     msg: "{{ ansible_distribution }} is not supported by this role"
-  when: ansible_distribution not in ['RedHat', 'CentOS', 'Fedora', 'Debian', 'Ubuntu', 'Archlinux']
+  when: ansible_distribution not in ['RedHat', 'CentOS', 'Fedora', 'Debian', 'Ubuntu', 'Archlinux', 'Amazon']
 
 - name: Fail if not a new release of Red Hat / CentOS
   fail:


### PR DESCRIPTION
Since the os_family is still Redhat it's an equivalence of RHEL.

